### PR TITLE
Create a basic cmake project to export the library target [ESD-1246] [ESD-1247]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-project(variant CXX)
 cmake_minimum_required(VERSION 2.8)
+
+project(variant CXX)
 
 add_library(variant INTERFACE)
 if(NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(variant CXX)
+cmake_minimum_required(VERSION 2.8)
+
+add_library(variant INTERFACE)
+if(NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)
+  target_include_directories(variant
+      SYSTEM INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+      )
+else()
+  target_include_directories(variant
+      INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+      )
+endif()
+


### PR DESCRIPTION
This is part of the epic to do with how we find and include project dependencies.

Variant previously did not support cmake. This PR adds a simple CMakeLists.txt to export the library target so that superprojects do not have to specify the variant include paths directly.