### PR TITLE
Standardize system include targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,10 @@ cmake_minimum_required(VERSION 2.8)
 project(variant CXX)
 
 add_library(variant INTERFACE)
-if(NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)
-  target_include_directories(variant
-      SYSTEM INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-      )
+if (DEFINED THIRD_PARTY_INCLUDES_AS_SYSTEM AND NOT THIRD_PARTY_INCLUDES_AS_SYSTEM)
+  target_include_directories(variant INTERFACE
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 else()
-  target_include_directories(variant
-      INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-      )
+  target_include_directories(variant SYSTEM INTERFACE
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 endif()
-


### PR DESCRIPTION
Although this PR is failing (even the master branch is now failing after rebuilding it in Travis :shrug: don't know why), I've tested that this works when updating the submodules for a number of PRs (see the list at the end of https://github.com/swift-nav/cmake/pull/62 for the exact number).

This PR will need to be update along with https://github.com/swift-nav/cmake/pull/62 to introduce the new standardized system include targets.